### PR TITLE
Update openai model name

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -87,7 +87,7 @@ def summarize(user_message):
     }
     
     data = {
-        "model": "gpt-4o",
+        "model": "gpt-4.1-mini",
         "messages": [
             {"role": "user", "content": f"{instructions}. \n\n NEWS in CSV format: {user_message}"}
         ],


### PR DESCRIPTION
## Summary
- fix the OpenAI model name spelling to `gpt-4.1-mini`

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68412d293094832aa65e1f98ac6f4636