### PR TITLE
Update model to gpt4.1-mini

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,5 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           INSTRUCTIONS: ${{ secrets.INSTRUCTIONS }}
           FEED_URLS: ${{ secrets.FEED_URLS }}
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
         run: python bot.py

--- a/bot.py
+++ b/bot.py
@@ -86,8 +86,10 @@ def summarize(user_message):
         "Authorization": f"Bearer {openai_api_key}"
     }
     
+    openai_model = os.getenv("OPENAI_MODEL", "gpt4.1-mini")
+
     data = {
-        "model": "gpt-4o",
+        "model": openai_model,
         "messages": [
             {"role": "user", "content": f"{instructions}. \n\n NEWS in CSV format: {user_message}"}
         ],

--- a/bot.py
+++ b/bot.py
@@ -86,7 +86,7 @@ def summarize(user_message):
         "Authorization": f"Bearer {openai_api_key}"
     }
     
-    openai_model = os.getenv("OPENAI_MODEL", "gpt4.1-mini")
+    openai_model = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
 
     data = {
         "model": openai_model,


### PR DESCRIPTION
## Summary
- use `gpt4.1-mini` as the default OpenAI model

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68412d293094832aa65e1f98ac6f4636