### PR TITLE
feat: migrate to Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # News Telegram Bot
 
-This script collects news from RSS feeds, summarizes the content with the OpenAI API and sends the result to a Telegram group.
+This script collects news from RSS feeds, summarizes the content with the OpenAI Responses API and sends the result to a Telegram group. Sampling parameters such as `temperature` or `top_p` are only included when explicitly provided, and the bot retries without unsupported fields if the API rejects them.
 
 ## Installation
 1. Clone this repository and navigate into it.


### PR DESCRIPTION
## Summary
- migrate summarization to OpenAI Responses API with optional sampling parameters and retry logic
- document Responses API usage in README and clarify retry behavior

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a73b70071c832a90165fae62c329e7